### PR TITLE
small edits

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -150,6 +150,7 @@ pygments_style = 'sphinx'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 html_theme = 'pydata_sphinx_theme'
+html_title = 'Predictably Sunny'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/posts/intro_to_bsrn.ipynb
+++ b/posts/intro_to_bsrn.ipynb
@@ -1986,7 +1986,7 @@
    "pygments_lexer": "ipython3",
    "version": "3.9.5"
   },
-  "title": "An introduction to the Baseline Surface Radiation Network (BSNR)"
+  "title": "An introduction to the Baseline Surface Radiation Network (BSRN)"
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/posts/staying_safe_on_github.md
+++ b/posts/staying_safe_on_github.md
@@ -18,7 +18,7 @@ Here's what that looked like afterward:
 
 This step is, however, not sufficient as the variables also have to be called in the workflow's `.yaml` file:
 
-```python
+```
     # Build the book
     - name: Build the site
       run: |


### PR DESCRIPTION
Here are some suggested small edits:

1) Set `html_theme` so that "documentation" doesn't show up in the window title:
    - before: ![image](https://user-images.githubusercontent.com/57452607/129646051-6b0930f5-9e71-47d6-968a-9c939b5f192e.png)
    - after: ![image](https://user-images.githubusercontent.com/57452607/129646081-6be16f1d-9c19-4f54-8845-e280a438af82.png)

2) Edit minor typo in a blog post title (BSNR -> BSRN)

3) Remove python syntax highlighting from a non-python code block to get rid of this build warning:  `staying_safe_on_github.md:21: WARNING: Could not lex literal_block as "python". Highlighting skipped.`
