### PR TITLE
Add commenting using giscus

### DIFF
--- a/_static/custom.css
+++ b/_static/custom.css
@@ -102,3 +102,8 @@ div.timeline div.entry.right::after {
     left: -.5em;
 }
 
+
+/* Blog post comments */
+.gsc-reactions {
+    margin-top: 1em;
+}

--- a/_templates/giscus.html
+++ b/_templates/giscus.html
@@ -1,0 +1,15 @@
+<script src="https://giscus.app/client.js"
+        data-repo="adamrjensen/adamrjensen.github.io"
+        data-repo-id="MDEwOlJlcG9zaXRvcnkzNzQ1MDc4Nzc="
+        data-category="Blog comments"
+        data-category-id="DIC_kwDOFlKJZc4CRySF"
+        data-mapping="pathname"
+        data-strict="0"
+        data-reactions-enabled="1"
+        data-emit-metadata="0"
+        data-input-position="bottom"
+        data-theme="preferred_color_scheme"
+        data-lang="en"
+        crossorigin="anonymous"
+        async>
+</script>

--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -1,0 +1,21 @@
+{%- extends "pydata_sphinx_theme/layout.html" %}
+
+{% block docs_body %}
+{{ super() }}
+<!-- Add a comment box underneath the page's content -->
+<script src="https://giscus.app/client.js"
+        data-repo="adamrjensen/adamrjensen.github.io"
+        data-repo-id="MDEwOlJlcG9zaXRvcnkzNzQ1MDc4Nzc="
+        data-category="Blog comments"
+        data-category-id="DIC_kwDOFlKJZc4CRySF"
+        data-mapping="pathname"
+        data-strict="0"
+        data-reactions-enabled="1"
+        data-emit-metadata="0"
+        data-input-position="bottom"
+        data-theme="preferred_color_scheme"
+        data-lang="en"
+        crossorigin="anonymous"
+        async>
+</script>
+{% endblock %}

--- a/conf.py
+++ b/conf.py
@@ -115,12 +115,6 @@ fontawesome_included = True
 # be linked to in HTML output by ABlog.
 # fontawesome_css_file = None
 
-# -- Disqus Integration -------------------------------------------------------
-
-# You can enable Disqus_ by setting ``disqus_shortname`` variable.
-# Disqus_ short name for the blog.
-disqus_shortname = 'adamrjensen'
-
 # -- Sphinx Options -----------------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be


### PR DESCRIPTION
Previously the site had Disqus integration, however, this meant that there were a lot of nasty ads at the bottom of the page.  This PR implements commenting using [giscus](https://giscus.app/).